### PR TITLE
Install core before base

### DIFF
--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -19,6 +19,17 @@
 # limitations under the License.
 #
 
+package 'r-base-core' do
+  version node['r']['version'] if node['r']['version']
+  action :install
+end
+
+package 'r-recommended' do
+  version node['r']['version'] if node['r']['version']
+  action :install
+end
+
+
 package 'r-base' do
   version node['r']['version'] if node['r']['version']
   action :install


### PR DESCRIPTION
Problem is that previously only r-base was installed but
`Depends: r-base-core (>= 3.2.3-4trusty0), r-recommended (= 3.2.3-4trusty0)`
So what would happen is that `r-base-core` would install 3.2.3-**6** and then be unable to install `r-recommended` 3.2.3-4 . I can't track down exactly what the problem is but if we lock r-base-core and r-recommended to be exactly the versions we want and installed before hand it goes smoothly
