### PR TITLE
options '--force-yes' on r-base-core package install

### DIFF
--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -23,6 +23,7 @@ package 'r-base-core' do
   version node['r']['version'] if node['r']['version']
   action :install
   ignore_failure true
+  options '--force-yes'
 end
 
 package 'r-recommended' do


### PR DESCRIPTION
```
2016-04-06_18:26:27.30113 ---- End output of apt-get -q -y install r-base-core=3.2.3-4trusty0 ----
2016-04-06_18:26:27.30114 Ran apt-get -q -y install r-base-core=3.2.3-4trusty0 returned 100
2016-04-06_18:26:27.30114
2016-04-06_18:26:27.30114 Resource Declaration:
2016-04-06_18:26:27.30116 ---------------------
2016-04-06_18:26:27.30118 # In /var/chef/git/tmp/librarian/cookbooks/r/recipes/install_package.rb
2016-04-06_18:26:27.30119
2016-04-06_18:26:27.30119  22: package 'r-base-core' do
2016-04-06_18:26:27.30119  23:   version node['r']['version'] if node['r']['version']
2016-04-06_18:26:27.30121  24:   action :install
2016-04-06_18:26:27.30122  25:   ignore_failure true
2016-04-06_18:26:27.30122  26: end
2016-04-06_18:26:27.30123  27:
```

```
$ sudo apt-get -q -y install r-base-core=3.2.3-4trusty0
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  ess r-doc-info r-doc-pdf r-mathlib
The following packages will be REMOVED:
  r-base r-cran-matrix r-cran-mgcv r-cran-nlme r-recommended
The following packages will be DOWNGRADED:
  r-base-core
0 upgraded, 0 newly installed, 1 downgraded, 5 to remove and 9 not upgraded.
Need to get 0 B/20.5 MB of archives.
After this operation, 10.8 MB disk space will be freed.
E: There are problems and -y was used without --force-yes
```

@udnay @jamesowenhall @kmtaylor-github @dklassen 
